### PR TITLE
[#139] Step2의 유사 문제 기능 추가 후 오른쪽 파트의 문제지 요약 목록이 출력되지 않는 문제

### DIFF
--- a/src/components/step/Step2Component.jsx
+++ b/src/components/step/Step2Component.jsx
@@ -702,10 +702,11 @@ export default function Step2Component() {
                                 </div>
                                 <div className="cnt-box type01">
                                     <Step2RightSideComponent
-                                        itemList={similarItems}
+                                        itemList={itemList}
                                         onDragEnd={handleDragEnd}
                                         onShowSimilar={(item) => handleSimilarPageToggle(item, itemList.indexOf(item) + 1)}
                                         questionIndex={questionIndex}
+                                        similarItems={similarItems}
                                     />
                                 </div>
                             </div>

--- a/src/components/step/Step2RightSideComponent.jsx
+++ b/src/components/step/Step2RightSideComponent.jsx
@@ -2,9 +2,9 @@ import React, {useState} from "react";
 import {DragDropContext} from "react-beautiful-dnd";
 import CommonResource from "../../util/CommonResource.jsx";
 import ExamSummaryComponent from "../common/ExamSummaryComponent.jsx";
-import Step2SimilarItems from "./Step2SimilarItems.jsx";
+import Step2SimilarItemsComponent from "./Step2SimilarItemsComponent.jsx";
 
-export default function Step2RightSideComponent({itemList, onDragEnd, onShowSimilar, questionIndex}) {
+export default function Step2RightSideComponent({itemList, onDragEnd, onShowSimilar, questionIndex, similarItems}) {
     const [activeTab, setActiveTab] = useState("summary");
     const [selectedItemId, setSelectedItemId] = useState(null);
 
@@ -47,8 +47,8 @@ export default function Step2RightSideComponent({itemList, onDragEnd, onShowSimi
                     {activeTab === "summary" ? (
                         <ExamSummaryComponent itemList={itemList} groupedItems={groupByPassage(itemList)}/>
                     ) : (
-                        <Step2SimilarItems
-                            items={itemList}
+                        <Step2SimilarItemsComponent
+                            items={similarItems}
                             onBack={() => setActiveTab("summary")}
                             questionNumber={questionIndex}
                         />

--- a/src/components/step/Step2SimilarItemsComponent.jsx
+++ b/src/components/step/Step2SimilarItemsComponent.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 import {getDifficultyColor} from "../../util/difficultyColorProvider.js";
 
-export default function Step2SimilarItems({items, onBack, questionNumber}) {
+export default function Step2SimilarItemsComponent({items, onBack, questionNumber}) {
     const [selectedDifficulty, setSelectedDifficulty] = useState("전체");
 
     const hasPassage = items.some((item) => item.passageId && item.passageUrl);


### PR DESCRIPTION
## resolve #139

## 변경사항
- Step2Component에서 Step2RightSideComponent로 similarItems를 보내도록 변경된 itemList를 다시 itemList를 전송하도록 변경
- Step2Component에서 Step2RightSideComponent로 보내는 similarItems 파라미터 추가
- Step2RightSideComponent에서 Step2SimilarItemsComponent로 보내는 파라미터를 itemList에서 similarItems로 변경

## 배포
- [ ] 성공
- [ ] 실패