### PR TITLE
[#170] Step2에서 오류 신고 시 동일 사용자가 중복된 오류 신고를 하면 중복 신고 메시지를 표시하는 기능 추가

### DIFF
--- a/src/components/step/Step2Component.jsx
+++ b/src/components/step/Step2Component.jsx
@@ -56,6 +56,7 @@ export default function Step2Component() {
     const [isErrorReportOpen, setIsErrorReportOpen] = useState(false);
     const [lastAddedItemId, setLastAddedItemId] = useState(null);
     const [isScopeModalOpen, setIsScopeModalOpen] = useState(false);
+    const [selectedItemId, setSelectedItemId] = useState(null);
 
     const location = useLocation();
     const step1Data = useLocation().state?.data || null;
@@ -82,7 +83,10 @@ export default function Step2Component() {
     const handleOpenModal = () => setIsModalOpen(true);
     const handleCloseModal = () => setIsModalOpen(false)
     const handleCloseNoSimilarItemsModal = () => setIsNoSimilarItemsModalOpen(false);
-    const handleOpenErrorReport = () => setIsErrorReportOpen(true);
+    const handleOpenErrorReport = (itemId) => {
+        setSelectedItemId(itemId);
+        setIsErrorReportOpen(true);
+    };
     const handleCloseErrorReport = () => setIsErrorReportOpen(false);
 
     const bookId = useSelector((state) => state.bookIdSlice);
@@ -588,7 +592,7 @@ export default function Step2Component() {
                 handleClose={handleCloseNoSimilarItemsModal}
                 open={isNoSimilarItemsModalOpen}
             />
-            <ErrorReportModal isOpen={isErrorReportOpen} onClose={handleCloseErrorReport}/>
+            <ErrorReportModal itemId={selectedItemId} isOpen={isErrorReportOpen} onClose={handleCloseErrorReport}/>
             <div id="wrap" className="full-pop-que">
                 <div className="full-pop-wrap">
                     <div className="pop-header">
@@ -758,7 +762,8 @@ export default function Step2Component() {
                                                                 </div>
                                                                 <div className="btn-wrap">
                                                                     <button type="button" className="btn-error pop-btn"
-                                                                            onClick={handleOpenErrorReport}></button>
+                                                                            onClick={() => handleOpenErrorReport(item.itemId)}
+                                                                    ></button>
 
                                                                     <button type="button"
                                                                             className="btn-delete"

--- a/src/components/step/Step2DeletedItemsComponent.jsx
+++ b/src/components/step/Step2DeletedItemsComponent.jsx
@@ -4,8 +4,12 @@ import ErrorReportModal from "../common/ErrorReportModalComponent.jsx";
 
 export default function DeletedItemsComponent({deletedItems, onRestoreItem}) {
     const [isErrorReportOpen, setIsErrorReportOpen] = useState(false);
+    const [selectedItemId, setSelectedItemId] = useState(null);
 
-    const handleOpenErrorReport = () => setIsErrorReportOpen(true);
+    const handleOpenErrorReport = (itemId) => {
+        setSelectedItemId(itemId);
+        setIsErrorReportOpen(true);
+    };
     const handleCloseErrorReport = () => setIsErrorReportOpen(false);
 
     const handleDeleteItem = (itemId) => {
@@ -19,7 +23,7 @@ export default function DeletedItemsComponent({deletedItems, onRestoreItem}) {
 
     return (
         <>
-            <ErrorReportModal isOpen={isErrorReportOpen} onClose={handleCloseErrorReport}/>
+            <ErrorReportModal itemId={selectedItemId} isOpen={isErrorReportOpen} onClose={handleCloseErrorReport}/>
             <div className="deleted-items-container" style={{
                 height: "100%",
                 overflowY: "auto",
@@ -58,8 +62,8 @@ export default function DeletedItemsComponent({deletedItems, onRestoreItem}) {
                                             </div>
                                             <div className="btn-wrap">
                                                 <button type="button" className="btn-error pop-btn"
-                                                        onClick={handleOpenErrorReport}>
-                                                </button>
+                                                        onClick={() => handleOpenErrorReport(item.itemId)}
+                                                ></button>
                                             </div>
                                         </div>
                                         <div className="view-que">

--- a/src/components/step/Step2SimilarItemsComponent.jsx
+++ b/src/components/step/Step2SimilarItemsComponent.jsx
@@ -5,6 +5,7 @@ import ErrorReportModal from "../common/ErrorReportModalComponent.jsx";
 export default function Step2SimilarItemsComponent({items, onBack, questionNumber, onAddItem}) {
     const [selectedDifficulty, setSelectedDifficulty] = useState("전체");
     const [isErrorReportOpen, setIsErrorReportOpen] = useState(false);
+    const [selectedItemId, setSelectedItemId] = useState(null);
 
     const hasPassage = items.some((item) => item.passageId && item.passageUrl);
 
@@ -34,12 +35,15 @@ export default function Step2SimilarItemsComponent({items, onBack, questionNumbe
         return groups;
     }, {});
 
-    const handleOpenErrorReport = () => setIsErrorReportOpen(true);
+    const handleOpenErrorReport = (itemId) => {
+        setSelectedItemId(itemId);
+        setIsErrorReportOpen(true);
+    };
     const handleCloseErrorReport = () => setIsErrorReportOpen(false);
 
     return (
         <>
-            <ErrorReportModal isOpen={isErrorReportOpen} onClose={handleCloseErrorReport}/>
+            <ErrorReportModal itemId={selectedItemId} isOpen={isErrorReportOpen} onClose={handleCloseErrorReport}/>
             <div className="similar-items-container" style={{
                 height: "100%",
                 overflowY: "auto",


### PR DESCRIPTION
## resolve #170

## 추가사항
- 오류 신고 시 로그인 사용자의 이메일 주소를 전송하도록 설정
- 천재교육 네트워크 환경을 고려해 카카오 로그인 실패 시 대체 이메일 주소 사용
- 서버에서 중복 확인 시 중복 신고 메시지 표시
- 다른 오류 발생 시 일반 오류 메시지 표시

## 배포
- [x] 성공
- [ ] 실패