### PR TITLE
[#201, #109, #111] Step1 데이터를 받아 오는 방식으로 변경 후 드래그 앤 드랍이 작동하지 않는 문제 해결

### DIFF
--- a/src/components/step/Step2Component.jsx
+++ b/src/components/step/Step2Component.jsx
@@ -471,8 +471,8 @@ export default function Step2Component() {
 
         if (!destination) return;
 
+        const updatedGroups = JSON.parse(JSON.stringify(groupedItems));
         if (type === "PASSAGE_GROUP") {
-            const updatedGroups = Array.from(groupedItems);
             const [movedGroup] = updatedGroups.splice(source.index, 1);
             updatedGroups.splice(destination.index, 0, movedGroup);
 
@@ -518,8 +518,23 @@ export default function Step2Component() {
 
             const group = updatedGroups[groupIndex];
 
-            const [movedItem] = group.items.splice(source.index, 1);
-            group.items.splice(destination.index, 0, movedItem);
+            const itemIndexInGroup = source.index - itemList.findIndex(item => item.passageId === sourcePassageIdNumber);
+
+            if (itemIndexInGroup < 0 || itemIndexInGroup >= group.items.length) {
+                console.error('item 인덱스가 존재하지 않습니다.');
+                return;
+            }
+
+            const [movedItem] = group.items.splice(itemIndexInGroup, 1);
+
+            if (!movedItem || !movedItem.itemId) {
+                console.error(`movedItem이 올바르지 않거나 itemId가 존재하지 않습니다: `, movedItem);
+                return;
+            }
+
+            const destinationIndexInGroup = destination.index - itemList.findIndex(item => item.passageId === destinationPassageIdNumber);
+
+            group.items.splice(destinationIndexInGroup, 0, movedItem);
 
             setGroupedItems(updatedGroups);
 


### PR DESCRIPTION
## resolve #201
## related to #109
## related to #111

## 변경사항
- #109 </br>#111 </br>의 방식 재적용
    - handleDragEnd 함수에서 지문 그룹 업데이트 시 깊은 복사를 통해 새로운 객체를 생성하도록 수정
    - handleDragEnd 함수에서 item의 index를 가져 오는 로직 수정

## 배포

- [x] 성공
- [ ] 실패