### PR TITLE
[#208] 유사 문제 또는 삭제 문항 탭으로 이동 시 step1Data.minorClassification의 값이 비어 있어 오류가 발생하는 문제 해결

### DIFF
--- a/src/components/step/Step2Component.jsx
+++ b/src/components/step/Step2Component.jsx
@@ -617,7 +617,7 @@ export default function Step2Component() {
                                 <div className="paper-info">
                                     <span>{subjectName}</span> {author}({curriculumYear})
                                 </div>
-                                {step1Data.minorClassification && (
+                                {minorClassification && (
                                     <button className="btn-default btn-research" onClick={handleReSearchClick}>
                                         <i className="research"></i>재검색
                                     </button>


### PR DESCRIPTION
## resolve #208

## 변경사항
- 재검색 버튼 노출 여부 판단 시 step1Data.minorClassification이 아닌 step1Data?.minorClassification를 통해 기 설정된 minorClassification 상수를 사용하도록 변경

## 배포
- [x] 성공
- [ ] 실패