### PR TITLE
[#265] 서비스 접속 후 서비스 URL 주소를 직접 입력해서 재접속 시 Step2의 문제 유형 포맷이 깨지는 문제 해결

### DIFF
--- a/src/components/step/Step0Component.jsx
+++ b/src/components/step/Step0Component.jsx
@@ -49,6 +49,10 @@ function Step0Component() {
       sessionStorage.setItem("isReloaded", "true");
       window.location.reload();
     }
+    
+    return () => {
+      sessionStorage.removeItem("isReloaded");
+    };
   }, []);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
## resolve #265

## 변경사항
- Step0Component에서 reload 후 sessionStorage의 isReloaded 키를 삭제하도록 수정

## 배포
- [x] 성공
- [ ] 실패