### PR TITLE
[#277] Step2의 우측 문제지 요약 부분 세로 길이를 좌측과 일치하도록 변경

### DIFF
--- a/src/components/common/ExamSummaryComponent.jsx
+++ b/src/components/common/ExamSummaryComponent.jsx
@@ -24,7 +24,7 @@ export default function ExamSummaryComponent({itemList, groupedItems}) {
 
     return (
         <div className="contents on">
-            <div className="table half-type no-passage" style={{overflowY: "auto", maxHeight: "400px"}}>
+            <div className="table half-type no-passage" style={{overflowY: "auto", maxHeight: "562px"}}>
                 <div className="fix-head">
                     <span className="move-header">이동</span>
                     <span className="number-header">번호</span>


### PR DESCRIPTION
## resolve #277

## 변경사항
- ExamSummaryComponent.jsx

## 배포
- [x] 성공
- [ ] 실패