### PR TITLE
[#279] Step2의 우측 사이드 문제지 요약 목록에서 스크롤 시 헤더는 이동하지 않도록 변경

### DIFF
--- a/src/components/common/ExamSummaryComponent.jsx
+++ b/src/components/common/ExamSummaryComponent.jsx
@@ -24,100 +24,103 @@ export default function ExamSummaryComponent({itemList, groupedItems}) {
 
     return (
         <div className="contents on">
-            <div className="table half-type no-passage" style={{overflowY: "auto", maxHeight: "562px"}}>
-                <div className="fix-head">
+            <div className="table half-type no-passage" style={{overflowY: "auto", maxHeight: "565px"}}>
+                <div className="fix-head" style={{position: "sticky", top: 0, backgroundColor: "#fff", zIndex: 1}}>
                     <span className="move-header">이동</span>
                     <span className="number-header">번호</span>
                     <span className="question-form-header">문제 형태</span>
                     <span className="question-type-header">문제 유형</span>
                     <span className="difficulty-header">난이도</span>
                 </div>
-                <Droppable droppableId="passageGroups" type="PASSAGE_GROUP">
-                    {(provided) => (
-                        <div
-                            ref={provided.innerRef}
-                            {...provided.droppableProps}
-                            className="test ui-sortable"
-                            id="table-1"
-                        >
-                            {sortedGroupedItems.map(({passageId, items}, groupIndex) => (
-                                <Draggable
-                                    key={`passage-${passageId}`}
-                                    draggableId={`passage-${passageId}`}
-                                    index={groupIndex}
-                                    isDragDisabled={passageId === "noPassage"}
-                                >
-                                    {(provided) => (
-                                        <div
-                                            ref={provided.innerRef}
-                                            {...provided.draggableProps}
-                                            className={`depth-01 ${passageId !== "noPassage" ? "has-passage" : "no-passage"}`}
-                                        >
-                                            {passageId !== "noPassage" && (
-                                                <div
-                                                    className="dragHandle ui-sortable-handle ico-move-type02"
-                                                    {...provided.dragHandleProps}
-                                                >
-                                                </div>
-                                            )}
-
-                                            <Droppable droppableId={`${passageId}`} type="ITEM">
-                                                {(innerProvided) => (
+                <div className="table-body" style={{overflowY: "auto", maxHeight: "516px"}}>
+                    <Droppable droppableId="passageGroups" type="PASSAGE_GROUP">
+                        {(provided) => (
+                            <div
+                                ref={provided.innerRef}
+                                {...provided.droppableProps}
+                                className="test ui-sortable"
+                                id="table-1"
+                            >
+                                {sortedGroupedItems.map(({passageId, items}, groupIndex) => (
+                                    <Draggable
+                                        key={`passage-${passageId}`}
+                                        draggableId={`passage-${passageId}`}
+                                        index={groupIndex}
+                                        isDragDisabled={passageId === "noPassage"}
+                                    >
+                                        {(provided) => (
+                                            <div
+                                                ref={provided.innerRef}
+                                                {...provided.draggableProps}
+                                                className={`depth-01 ${passageId !== "noPassage" ? "has-passage" : "no-passage"}`}
+                                            >
+                                                {passageId !== "noPassage" && (
                                                     <div
-                                                        ref={innerProvided.innerRef}
-                                                        {...innerProvided.droppableProps}
-                                                        className="col-group"
+                                                        className="dragHandle ui-sortable-handle ico-move-type02"
+                                                        {...provided.dragHandleProps}
                                                     >
-                                                        {items.map((item) => {
-                                                            const overallIndex = itemList.findIndex(i => i.itemId === item.itemId);
-                                                            return (
-                                                                <Draggable
-                                                                    key={`item-${item.itemId}`}
-                                                                    draggableId={`item-${item.itemId}`}
-                                                                    index={overallIndex}
-                                                                >
-                                                                    {(provided) => (
-                                                                        <div
-                                                                            className="col depth-02"
-                                                                            ref={provided.innerRef}
-                                                                            {...provided.draggableProps}
-                                                                            {...provided.dragHandleProps}
-                                                                            onClick={() => handleScrollToQuestion(item.itemId)}
-                                                                        >
-                                                                            <a href="#">
+                                                    </div>
+                                                )}
+
+                                                <Droppable droppableId={`${passageId}`} type="ITEM">
+                                                    {(innerProvided) => (
+                                                        <div
+                                                            ref={innerProvided.innerRef}
+                                                            {...innerProvided.droppableProps}
+                                                            className="col-group"
+                                                        >
+                                                            {items.map((item) => {
+                                                                const overallIndex = itemList.findIndex(i => i.itemId === item.itemId);
+                                                                return (
+                                                                    <Draggable
+                                                                        key={`item-${item.itemId}`}
+                                                                        draggableId={`item-${item.itemId}`}
+                                                                        index={overallIndex}
+                                                                    >
+                                                                        {(provided) => (
+                                                                            <div
+                                                                                className="col depth-02"
+                                                                                ref={provided.innerRef}
+                                                                                {...provided.draggableProps}
+                                                                                {...provided.dragHandleProps}
+                                                                                onClick={() => handleScrollToQuestion(item.itemId)}
+                                                                            >
+                                                                                <a href="#">
                                                                                 <span
                                                                                     className="dragHandle ui-sortable-handle ico-move-type01"></span>
-                                                                                <span>{overallIndex + 1}</span>
-                                                                                <span className="tit">
+                                                                                    <span>{overallIndex + 1}</span>
+                                                                                    <span className="tit">
                                                                                     <div className="txt">
                                                                                         {truncateText(`${item.largeChapterName} > ${item.mediumChapterName} > ${item.smallChapterName} > ${item.topicChapterName}`, 30)}
                                                                                     </div>
                                                                                 </span>
-                                                                                <span className="question-type-data">
+                                                                                    <span
+                                                                                        className="question-type-data">
                                                                                     {item.questionFormCode <= 50 ? "객관식" : "주관식"}
                                                                                 </span>
-                                                                                <span>
+                                                                                    <span>
                                                                                     <span
                                                                                         className={`que-badge ${item.difficultyName}`}>{item.difficultyName}</span>
                                                                                 </span>
-                                                                            </a>
-                                                                        </div>
-                                                                    )}
-                                                                </Draggable>
-                                                            );
-                                                        })}
-                                                        {innerProvided.placeholder}
-                                                    </div>
-                                                )}
-                                            </Droppable>
-                                        </div>
-                                    )}
-                                </Draggable>
-                            ))}
-                            {provided.placeholder}
-                        </div>
-                    )}
-                </Droppable>
+                                                                                </a>
+                                                                            </div>
+                                                                        )}
+                                                                    </Draggable>
+                                                                );
+                                                            })}
+                                                            {innerProvided.placeholder}
+                                                        </div>
+                                                    )}
+                                                </Droppable>
+                                            </div>
+                                        )}
+                                    </Draggable>
+                                ))}
+                                {provided.placeholder}
+                            </div>
+                        )}
+                    </Droppable>
+                </div>
             </div>
             <QuesionTypeCountComponent itemList={itemList}/>
         </div>

--- a/src/components/step/Step2Component.jsx
+++ b/src/components/step/Step2Component.jsx
@@ -335,7 +335,6 @@ export default function Step2Component() {
 
     useEffect(() => {
         document.body.style.zoom = "125%";
-        // 또는 방법 2: transform scale 사용
         document.body.style.transform = "scale(0.67)";
         document.body.style.transformOrigin = "top ";
         return () => {


### PR DESCRIPTION
## resolve #279

## 변경사항
- ExamSummaryComponent.jsx

## 배포
- [x] 성공
- [ ] 실패